### PR TITLE
Fix: credentialId was not retained in config

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
@@ -63,15 +63,22 @@ import static org.apache.commons.lang.StringUtils.isNotBlank;
  */
 public class CodeCommitURLHelper extends GitSCMExtension {
     private String credentialId;
+    private String repositoryName;
 
     @DataBoundConstructor
     public CodeCommitURLHelper(String credentialId, String repositoryName) {
         this.credentialId = credentialId;
+        this.repositoryName = repositoryName;
     }
 
     public String getCredentialId() {
         return this.credentialId;
     }
+
+    public String getRepositoryName() {
+        return this.repositoryName;
+    }
+
 
     private static final class RepositoryUsernameReference {
         private final UsernamePasswordCredentialsImpl credential;

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
@@ -210,15 +210,20 @@ public class CodeCommitURLHelper extends GitSCMExtension {
 
         public AbstractIdCredentialsListBoxModel<?, ?> doFillCredentialIdItems(
                 @AncestorInPath Item owner) {
-            if (owner == null || !owner.hasPermission(Item.CONFIGURE)) {
+
+            if (owner != null && !owner.hasPermission(Item.CONFIGURE)) {
                 return new AWSCredentialsListBoxModel();
             }
 
-            List<AmazonWebServicesCredentials>
-                    creds =
-                    CredentialsProvider
+            List<AmazonWebServicesCredentials> creds;
+            if (owner == null) {
+                // no owner (e.g. no Job), this happens on the "Configure System" page when adding a Global Library
+                creds = CredentialsProvider.lookupCredentials(AmazonWebServicesCredentials.class);
+            } else {
+                creds = CredentialsProvider
                             .lookupCredentials(AmazonWebServicesCredentials.class, owner, ACL.SYSTEM,
                                     Collections.<DomainRequirement>emptyList());
+            }
 
             return new AWSCredentialsListBoxModel()
                     .withEmptySelection()

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/codecommit/CodeCommitURLHelper.java
@@ -69,6 +69,10 @@ public class CodeCommitURLHelper extends GitSCMExtension {
         this.credentialId = credentialId;
     }
 
+    public String getCredentialId() {
+        return this.credentialId;
+    }
+
     private static final class RepositoryUsernameReference {
         private final UsernamePasswordCredentialsImpl credential;
 
@@ -228,4 +232,3 @@ public class CodeCommitURLHelper extends GitSCMExtension {
         }
     }
 }
-


### PR DESCRIPTION
Fixes https://github.com/ingenieux/codecommit-url-helper/issues/4

Steps to reproduce:

1. specify credentialId in configure page
2. save
3. reload page
4. credentialId has gone, but should still be there

